### PR TITLE
Handle TIFFs without embedded previews

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -62,6 +62,7 @@ class Application extends App
             'srf' => ['image/x-dcraw'],
             'srw' => ['image/x-dcraw'],
             'tif' => ['image/x-dcraw'],
+            'tiff' => ['image/x-dcraw'],
             'x3f' => ['image/x-dcraw'],
         ];
         $mimeTypeDetector->registerTypeArray($mimesToDetect);


### PR DESCRIPTION
When imagick extension with TIFF support is found also handle TIFF files without embedded previews by generating a preview from the whole file.

closes #39

Can also handle multipage TIFFs without embedded preview (first page gets previewed)