### PR TITLE
Remove HEIC support and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 
 A Nextcloud app that provides previews for camera **RAW** images like .CR2, .CRW, .DNG, .MRW, .NEF, .NRW, .RW2, .SRW, .SRW, etc.
 
-This app also gives you preview of Adobe **Indesign** files (.INDD) and **HEIC** photos.
+This app also gives you preview of Adobe **Indesign** files (.INDD) photos.
 
 
 ## Requirements
 * Probably **memory_limit** quite high.
 * **imagick** or **gd** module. If imagick is available, it will use that for performance.
 * For files with a TIFF preview (at least some DNG files), **imagick** is required
-* For HEIC previews, **imagick** with HEIC support is required
 
 ## Installation
 Install in Nextcloud App store.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
     <summary>Preview and show camera RAW files in Nextcloud</summary>
     <description>
         <![CDATA[This app will make previews of &quot;RAW&quot; files from cameras in Nextcloud.]]></description>
-    <version>0.8.0</version>
+    <version>0.8.1</version>
     <licence>agpl</licence>
     <author mail="ari@selseng.net" >Ari Selseng</author>
     <namespace>CameraRawPreviews</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -46,7 +46,6 @@ class Application extends App implements IBootstrap
 
         $mimesToDetect = [
             'indd' => ['image/x-indesign'],
-            'heic' => ['image/heic'],
             '3fr' => ['image/x-dcraw'],
             'arw' => ['image/x-dcraw'],
             'cr2' => ['image/x-dcraw'],
@@ -75,7 +74,7 @@ class Application extends App implements IBootstrap
         ];
 
         $mimeTypeDetector->registerTypeArray($mimesToDetect);
-        $context->registerPreviewProvider(RawPreviewIProviderV2::class, '/^((image\/x-dcraw)|(image\/x-indesign)|(image\/heic))(;+.*)*$/');
+        $context->registerPreviewProvider(RawPreviewIProviderV2::class, '/^((image\/x-dcraw)|(image\/x-indesign))(;+.*)*$/');
     }
 
     public function boot(IBootContext $context): void {

--- a/lib/RawPreviewBase.php
+++ b/lib/RawPreviewBase.php
@@ -35,7 +35,7 @@ class RawPreviewBase
      */
     public function getMimeType()
     {
-        return '/^((image\/x-dcraw)|(image\/x-indesign)|(image\/heic))(;+.*)*$/';
+        return '/^((image\/x-dcraw)|(image\/x-indesign))(;+.*)*$/';
     }
 
     /**
@@ -181,14 +181,6 @@ class RawPreviewBase
             return ['tag' => 'SourceFile', 'ext' => 'tiff'];
         }
 
-        if (in_array($fileType, ['HEIFS', 'HEIF', 'HEIC', 'HEICS'], true)) {
-            if ($this->isHeicCompatible()) {
-               return ['tag' => 'SourceFile', 'ext' => 'heic'];
-            }
-
-            throw new Exception('Needs imagick with HEIC support HEIC previews');
-        }
-
         // extra logic for tiff previews
         foreach ($tiffTagsToCheck as $tag) {
             if (!isset($previewData[0][$tag])) {
@@ -251,14 +243,6 @@ class RawPreviewBase
     private function isTiffCompatible()
     {
         return $this->getDriver() === self::DRIVER_IMAGICK && count(\Imagick::queryFormats('TIFF')) > 0;
-    }
-
-    /**
-     * @return bool
-     */
-    private function isHeicCompatible()
-    {
-        return $this->getDriver() === self::DRIVER_IMAGICK && count(\Imagick::queryFormats('HEIC')) > 0;
     }
 
     /**

--- a/tests/RawPreviewIProviderV2Test.php
+++ b/tests/RawPreviewIProviderV2Test.php
@@ -43,11 +43,6 @@ class RawPreviewTestIProviderV2 extends TestCase
             'url' => 'https://raw.pixls.us/data/Hasselblad/CF132/RAW_HASSELBLAD_IXPRESS_CF132.3FR',
             'filename' => 'Hasselblad_CF132.3FR',
             'sha1' => 'bcaa4c329711a8effb59682a99df3f2b15009d87'
-        ],
-        [
-            'url' => 'https://filesamples.com/samples/image/heic/sample1.heic',
-            'filename' => 'sample1.heic',
-            'sha1' => 'ff0ed3774c4f905357c7918a5dfbeb54ab04f3d7'
         ]
     ];
 


### PR DESCRIPTION
Reverts 301631f, 7b2da1d and 04f3e43

As [mentioned in the official documentation](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/config_sample_php_parameters.html#previews), Nextcloud 25 (and older supported versions) natively supports HEIC previews.
This pull request removes the redundant support, testing and documentation of HEIC previews introduced by  #83 from this application.