### PR TITLE
add RAWViewer legacy component for DNG/DCRAW previews

### DIFF
--- a/js/register-viewer.js
+++ b/js/register-viewer.js
@@ -1,9 +1,36 @@
-	if (OCA.Viewer) {
-		OCA.Viewer.registerHandler({
-			id: 'camerarawpreviews',
-			mimesAliases: {
-				'image/x-dcraw': 'image/jpeg'
+if (OCA.Viewer) {
+	const RAWViewer = {
+		name: 'RAWViewer',
+		props: {
+			filename: { type: String, default: null },
+			previewPath: { type: String, default: null },
+		},
+		render(createElement) {
+			if (!this.previewPath) {
+				return createElement('div', 'Preview not available')
 			}
-		})
+			const url = OC.generateUrl(this.previewPath)
+			return createElement('img', {
+				attrs: {
+					src: url,
+					alt: this.filename || 'RAW preview',
+					style: 'max-width: 100%; max-height: 100%; object-fit: contain;',
+				},
+				on: {
+					load: () => {
+						this.doneLoading()
+					}
+				}
+			})
+		},
 	}
 
+	OCA.Viewer.registerHandler({
+		id: 'camerarawpreviews',
+		group: 'media',
+		mimes: [
+			'image/x-dcraw',
+		],
+		component: RAWViewer,
+	})
+}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -34,7 +34,7 @@ class Application extends App implements IBootstrap
 
         $eventDispatcher = $context->getServerContainer()->get(IEventDispatcher::class);
         $eventDispatcher->addListener(\OCA\Viewer\Event\LoadViewer::class, function () {
-            Util::addScript($this->appName, 'register-viewer');  // adds js/script.js
+            Util::addInitScript($this->appName, 'register-viewer');  // adds js/script.js
         });
     }
 


### PR DESCRIPTION
Fix the RAWViewer registration and loading issues reported in:

* [[Nextcloud Viewer #2960](https://github.com/nextcloud/viewer/issues/2960)](https://github.com/nextcloud/viewer/issues/2960)
* [[CameraRAWPreviews #115](https://github.com/ariselseng/camerarawpreviews/issues/115)](https://github.com/ariselseng/camerarawpreviews/issues/115)

This update adds a proper legacy RAWViewer component for DNG/DCraw previews, ensures the preview image is correctly loaded via the preview generator, and signals to the Viewer when the image is ready, so the loading spinner disappears as expected.