### PR TITLE
feat: Nextcloud 33 + PHP 8.4 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
     <bugs>https://github.com/ariselseng/camerarawpreviews/issues</bugs>
     <dependencies>
         <php min-version="8.1"></php>
-        <nextcloud min-version="29" max-version="32"/>
+        <nextcloud min-version="29" max-version="33"/>
     </dependencies>
     <types><filesystem/></types>
 </info>

--- a/lib/RawPreviewBase.php
+++ b/lib/RawPreviewBase.php
@@ -16,11 +16,11 @@ use Psr\Log\LoggerInterface;
 
 class RawPreviewBase
 {
-    protected $converter;
-    protected $driver;
-    protected $logger;
-    protected $appName;
-    protected $tmpFiles = [];
+    protected ?string $converter = null;
+    protected ?string $driver = null;
+    protected LoggerInterface $logger;
+    protected string $appName;
+    protected array $tmpFiles = [];
 
     public function __construct(LoggerInterface $logger)
     {

--- a/lib/RawPreviewIProviderV2.php
+++ b/lib/RawPreviewIProviderV2.php
@@ -6,7 +6,6 @@ use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
 use OCP\Preview\IProviderV2;
-use OCP\Preview\IProvider2;
 
 class RawPreviewIProviderV2 extends RawPreviewBase implements IProviderV2
 {


### PR DESCRIPTION
## Summary

Add compatibility with **Nextcloud 33** and **PHP 8.4**.

## Changes

### info.xml
- Bump `max-version` from 32 to 33

### RawPreviewBase.php — PHP 8.4 property typing
PHP 8.4 deprecates implicit nullable and untyped class properties. Added explicit type declarations:

| Property | Before | After |
|---|---|---|
| `$converter` | untyped | `?string $converter = null` |
| `$driver` | untyped | `?string $driver = null` |
| `$logger` | untyped | `LoggerInterface $logger` |
| `$appName` | untyped | `string $appName` |
| `$tmpFiles` | untyped | `array $tmpFiles = []` |

### RawPreviewIProviderV2.php
- Remove unused `OCP\Preview\IProvider2` import (interface does not exist in NC33)

## Testing
- Tested on Nextcloud 33.0.2 with PHP 8.4
- RAW file previews (CR2, NEF, ARW, DNG) generate correctly
- Viewer integration works as expected